### PR TITLE
Improvements to Aurora chocolatey package

### DIFF
--- a/manual/project-aurora/project-aurora.nuspec
+++ b/manual/project-aurora/project-aurora.nuspec
@@ -69,7 +69,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/antonpup/Aurora/master/Project-Aurora/Project-Aurora/Resources/aurora_logo_256x256.png</iconUrl>
 	<dependencies>
-    <dependency id="vcredist2017" />
+    <dependency id="vcredist140" version="14.10.25008.0" />
   </dependencies>
   </metadata>
   <files>

--- a/manual/project-aurora/project-aurora.nuspec
+++ b/manual/project-aurora/project-aurora.nuspec
@@ -68,9 +68,6 @@
     <tags>rgb logitech corsair razer clevo cooler master steelseries wooting roccat alienware playStation drevo soundblaster asus yeelight nzxt</tags>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/antonpup/Aurora/master/Project-Aurora/Project-Aurora/Resources/aurora_logo_256x256.png</iconUrl>
-	<dependencies>
-    <dependency id="vcredist140" version="14.10.25008.0" />
-  </dependencies>
   </metadata>
   <files>
 	  <file src="tools\**" target="tools" />

--- a/manual/project-aurora/project-aurora.nuspec
+++ b/manual/project-aurora/project-aurora.nuspec
@@ -64,6 +64,7 @@
     <packageSourceUrl>https://github.com/kwilliams1987/chocolatey-packages/tree/master/manual/project-aurora</packageSourceUrl>
     <docsUrl>https://www.project-aurora.com/help.html</docsUrl>
     <mailingListUrl>https://github.com/antonpup/Aurora/issues</mailingListUrl>
+    <licenseUrl>https://github.com/antonpup/Aurora/blob/master/LICENSE</licenseUrl>
     <tags>rgb logitech corsair razer clevo cooler master steelseries wooting roccat alienware playStation drevo soundblaster asus yeelight nzxt</tags>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://raw.githubusercontent.com/antonpup/Aurora/master/Project-Aurora/Project-Aurora/Resources/aurora_logo_256x256.png</iconUrl>

--- a/manual/project-aurora/tools/chocolateyInstall.ps1
+++ b/manual/project-aurora/tools/chocolateyInstall.ps1
@@ -1,3 +1,3 @@
-Install-ChocolateyPackage "Project Aurora" "exe" "/silent" `
+Install-ChocolateyPackage "Project Aurora" "exe" "/verysilent" `
     "https://github.com/antonpup/Aurora/releases/download/v0.8.1/Aurora-setup-v0.8.1.exe" `
     -checksum "2f38c350cfd8aa7bdf938348bbf3e01e62d5e411d73db8ba325e0bcbb8b0dd99" -checksumType "sha256"


### PR DESCRIPTION
Noticed that the newly updated package you pushed to the community feed was still pending moderation eight days after its 2020-06-15 submission date.  There two moderation warnings that might've flagged it for additional review:
- DependencyWithNoVersion
- LicenseUrlMissing

So I thought I'd tackle those along with my recommendation to switch from the `/silent` install option to the generally preferred `/verysilent` option that prevents the install GUI from ever displaying (usually the best option for any CLI package manager).

Also, your package listed _vcredist2017_ as a dependency, but that is simply a metapackage pointing to the _vcredist140_ package.  It's much more efficient to point directly to the source package.  _vcredist140_ covers all releases from 2015-2019, so by specifying a minimum version (which appeases the moderator warning) that corresponds to the 2017 RTM version, anyone who has any version of _vcredist2017_ or _vcredist2019_ will meet the dependency requirement.  No need to force a user to install 2017 when they already have 2019 installed.

I hope you find the adjustments welcome when it comes time to publish the next release of Aurora.